### PR TITLE
Make Proton's DXVK DLLs writable before copying

### DIFF
--- a/updxvk
+++ b/updxvk
@@ -398,6 +398,9 @@ if [ "$1" == "proton-dist" ] && [ -n "$_proton_dist_path" ]; then
 
       source "$ROOT/DXVKBUILD/$DXVK_BRANCH/last-HEAD"
 
+      chmod +w "$_proton_dist_path"/lib64/wine/dxvk/*
+      chmod +w "$_proton_dist_path"/lib/wine/dxvk/*
+
       \cp -rv ./DXVKBUILD/"$DXVK_BRANCH"/"$CURRENT_HEAD"/x64/* "$_proton_dist_path"/lib64/wine/dxvk
       \cp -rv ./DXVKBUILD/"$DXVK_BRANCH"/"$CURRENT_HEAD"/x32/* "$_proton_dist_path"/lib/wine/dxvk
 


### PR DESCRIPTION
Looks like Proton's DXVK DLLs aren't writable by default anymore, let's `chmod +w` them then before copying. Hopefully it's fine to keep them writable so we don't have to make the code more complicated :frog: (to keep them writable when older proton is used for example)