### PR TITLE
Update to new lutris directory scheme

### DIFF
--- a/upvkd3d-proton
+++ b/upvkd3d-proton
@@ -196,12 +196,14 @@ if [ "$1" == "lutris" ]; then
 
       source "$ROOT/VKD3D_PROTONBUILD/$VKD3D_PROTON_BRANCH/last-HEAD"
 
+      rm -rv "$HOME"/.local/share/lutris/runtime/vkd3d/TkG/x64/d3d12.dll
+      rm -rv "$HOME"/.local/share/lutris/runtime/vkd3d/TkG/x32/d3d12.dll
       rm -rv "$HOME"/.local/share/lutris/runtime/dxvk/TkG/x64/d3d12.dll
       rm -rv "$HOME"/.local/share/lutris/runtime/dxvk/TkG/x32/d3d12.dll
-      mkdir -p "$HOME"/.local/share/lutris/runtime/dxvk/TkG/x64
-      mkdir -p "$HOME"/.local/share/lutris/runtime/dxvk/TkG/x32
-      cp -rv ./VKD3D_PROTONBUILD/"$VKD3D_PROTON_BRANCH"/"$CURRENT_HEAD"/x64/* "$HOME"/.local/share/lutris/runtime/dxvk/TkG/x64
-      cp -rv ./VKD3D_PROTONBUILD/"$VKD3D_PROTON_BRANCH"/"$CURRENT_HEAD"/x86/* "$HOME"/.local/share/lutris/runtime/dxvk/TkG/x32
+      mkdir -p "$HOME"/.local/share/lutris/runtime/vkd3d/TkG/x64
+      mkdir -p "$HOME"/.local/share/lutris/runtime/vkd3d/TkG/x32
+      cp -rv ./VKD3D_PROTONBUILD/"$VKD3D_PROTON_BRANCH"/"$CURRENT_HEAD"/x64/* "$HOME"/.local/share/lutris/runtime/vkd3d/TkG/x64
+      cp -rv ./VKD3D_PROTONBUILD/"$VKD3D_PROTON_BRANCH"/"$CURRENT_HEAD"/x86/* "$HOME"/.local/share/lutris/runtime/vkd3d/TkG/x32
 
       echo ""
       echo "###########################################################"


### PR DESCRIPTION
Lutris has recently updated it's runtime directory scheme and now separates vkd3d and dxvk. This PR crudely changes the upvkd3d script to copy the d3d12.dll to the now separate vkd3d directory.
It doesn't handle copying the setup_vkd3d_proton.sh script because I don't know where that would be handled in the first place.